### PR TITLE
Fix issue #5 (Parentheses issue in Markdown)

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,4 +1,4 @@
 The Jingle Bells MIDI file is public domain music transcribed by
 [Hyacinth](https://commons.wikimedia.org/wiki/User:Hyacinth)
 and made available on
-(Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Jingle_Bells_full_Ab.mid).
+[Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Jingle_Bells_full_Ab.mid).


### PR DESCRIPTION
I noticed that a paretheses was used instead of a bracket in the markdown file. I have fixed the issue by replacing the paretheses with a bracket. This change ensures that the link will display correctly in the markdown file.